### PR TITLE
Run check & test jobs on Linux, macOS, & Windows with stable, beta, & nightly Rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,23 +7,51 @@ on:
 
 jobs:
   check:
-    name: check
-    runs-on: ubuntu-latest
+    name: check - ${{ matrix.platform.os_name }} with rust ${{ matrix.toolchain }}
+    runs-on: ${{ matrix.platform.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - os_name: Linux
+            os: ubuntu-latest
+          - os_name: macOS
+            os: macOS-latest
+          - os_name: Windows
+            os: windows-latest
+        toolchain:
+          - stable
+          - beta
+          - nightly
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.toolchain }}
       - run: cargo check --all --all-targets --all-features
 
   test:
-    name: test
-    runs-on: ubuntu-latest
+    name: test - ${{ matrix.platform.os_name }} with rust ${{ matrix.toolchain }}
+    runs-on: ${{ matrix.platform.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - os_name: Linux
+            os: ubuntu-latest
+          - os_name: macOS
+            os: macOS-latest
+          - os_name: Windows
+            os: windows-latest
+        toolchain:
+          - stable
+          - beta
+          - nightly
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.toolchain }}
       - run: cargo test --workspace --all-features
 
   fmt:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
             os: windows-latest
         toolchain:
           - stable
-          - beta
           - nightly
     steps:
       - uses: actions/checkout@v3
@@ -45,7 +44,6 @@ jobs:
             os: windows-latest
         toolchain:
           - stable
-          - beta
           - nightly
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
           - os_name: Linux
             os: ubuntu-latest
           - os_name: macOS
-            os: macOS-latest
+            os: macos-latest
           - os_name: Windows
             os: windows-latest
         toolchain:
@@ -39,7 +39,7 @@ jobs:
           - os_name: Linux
             os: ubuntu-latest
           - os_name: macOS
-            os: macOS-latest
+            os: macos-latest
           - os_name: Windows
             os: windows-latest
         toolchain:


### PR DESCRIPTION
This would be faster (and less repetitive) if I combined the check & test jobs in one but I didn't want to change too much at first. If you want, I'm happy to make that change.

For some reason this didn't run in Actions when I pushed it to my fork, so I'm not sure it works yet. Maybe it will run when I create this PR.