### PR TITLE
Add support for mm-dd-yyyy format

### DIFF
--- a/dateparser/src/datetime.rs
+++ b/dateparser/src/datetime.rs
@@ -32,6 +32,7 @@ where
             .or_else(|| self.month_mdy_family(input))
             .or_else(|| self.month_dmy_family(input))
             .or_else(|| self.slash_mdy_family(input))
+            .or_else(|| self.hyphen_mdy_family(input))
             .or_else(|| self.slash_ymd_family(input))
             .or_else(|| self.dot_mdy_or_ymd(input))
             .or_else(|| self.mysql_log_timestamp(input))
@@ -95,6 +96,16 @@ where
             return None;
         }
         self.slash_mdy_hms(input).or_else(|| self.slash_mdy(input))
+    }
+
+    fn hyphen_mdy_family(&self, input: &str) -> Option<Result<DateTime<Utc>>> {
+        lazy_static! {
+            static ref RE: Regex = Regex::new(r"^[0-9]{1,2}-[0-9]{1,2}").unwrap();
+        }
+        if !RE.is_match(input) {
+            return None;
+        }
+        self.hyphen_mdy_hms(input).or_else(|| self.hyphen_mdy(input))
     }
 
     fn slash_ymd_family(&self, input: &str) -> Option<Result<DateTime<Utc>>> {
@@ -696,6 +707,74 @@ where
             .ok()
             .map(|parsed| parsed.and_time(time))
             .and_then(|datetime| self.tz.from_local_datetime(&datetime).single())
+            .map(|at_tz| at_tz.with_timezone(&Utc))
+            .map(Ok)
+    }
+
+    // mm-dd-yyyy
+    // - 3-31-2014
+    // - 03-3-2014
+    // - 08-21-71
+    // - 8-1-71
+    fn hyphen_mdy(&self, input: &str) -> Option<Result<DateTime<Utc>>> {
+        lazy_static! {
+            static ref RE: Regex = Regex::new(r"^[0-9]{1,2}-[0-9]{1,2}-[0-9]{2,4}$").unwrap();
+        }
+        if !RE.is_match(input) {
+            return None;
+        }
+
+        // set time to use
+        let time = match self.default_time {
+            Some(v) => v,
+            None => Utc::now().with_timezone(self.tz).time(),
+        };
+
+        NaiveDate::parse_from_str(input, "%m-%d-%y")
+            .or_else(|_| NaiveDate::parse_from_str(input, "%m-%d-%Y"))
+            .ok()
+            .map(|parsed| parsed.and_time(time))
+            .and_then(|datetime| self.tz.from_local_datetime(&datetime).single())
+            .map(|at_tz| at_tz.with_timezone(&Utc))
+            .map(Ok)
+    }
+
+    // mm-dd-yyyy hh:mm:ss
+    // - 4-8-2014 22:05
+    // - 04-08-2014 22:05
+    // - 4-8-14 22:05
+    // - 04-2-2014 03:00:51
+    // - 8-8-1965 12:00:00 AM
+    // - 8-8-1965 01:00:01 PM
+    // - 8-8-1965 01:00 PM
+    // - 8-8-1965 1:00 PM
+    // - 8-8-1965 12:00 AM
+    // - 4-02-2014 03:00:51
+    // - 03-19-2012 10:11:59
+    // - 03-19-2012 10:11:59.3186369
+    fn hyphen_mdy_hms(&self, input: &str) -> Option<Result<DateTime<Utc>>> {
+        lazy_static! {
+            static ref RE: Regex = Regex::new(
+                r"^[0-9]{1,2}-[0-9]{1,2}-[0-9]{2,4}\s+[0-9]{1,2}:[0-9]{2}(:[0-9]{2})?(\.[0-9]{1,9})?\s*(am|pm|AM|PM)?$"
+            )
+            .unwrap();
+        }
+        if !RE.is_match(input) {
+            return None;
+        }
+
+        self.tz
+            .datetime_from_str(input, "%m-%d-%y %H:%M:%S")
+            .or_else(|_| self.tz.datetime_from_str(input, "%m-%d-%y %H:%M"))
+            .or_else(|_| self.tz.datetime_from_str(input, "%m-%d-%y %H:%M:%S%.f"))
+            .or_else(|_| self.tz.datetime_from_str(input, "%m-%d-%y %I:%M:%S %P"))
+            .or_else(|_| self.tz.datetime_from_str(input, "%m-%d-%y %I:%M %P"))
+            .or_else(|_| self.tz.datetime_from_str(input, "%m-%d-%Y %H:%M:%S"))
+            .or_else(|_| self.tz.datetime_from_str(input, "%m-%d-%Y %H:%M"))
+            .or_else(|_| self.tz.datetime_from_str(input, "%m-%d-%Y %H:%M:%S%.f"))
+            .or_else(|_| self.tz.datetime_from_str(input, "%m-%d-%Y %I:%M:%S %P"))
+            .or_else(|_| self.tz.datetime_from_str(input, "%m-%d-%Y %I:%M %P"))
+            .ok()
             .map(|at_tz| at_tz.with_timezone(&Utc))
             .map(Ok)
     }
@@ -1472,6 +1551,80 @@ mod tests {
         }
         assert!(parse.slash_mdy("not-date-time").is_none());
     }
+
+    #[test]
+    fn hyphen_mdy() {
+        let parse = Parse::new(&Utc, None);
+
+        let test_cases = [
+            (
+                "3-31-2014",
+                Utc.ymd(2014, 3, 31).and_time(Utc::now().time()),
+            ),
+            (
+                "03-31-2014",
+                Utc.ymd(2014, 3, 31).and_time(Utc::now().time()),
+            ),
+            ("08-21-71", Utc.ymd(1971, 8, 21).and_time(Utc::now().time())),
+            ("8-1-71", Utc.ymd(1971, 8, 1).and_time(Utc::now().time())),
+        ];
+
+        for &(input, want) in test_cases.iter() {
+            assert_eq!(
+                parse
+                    .hyphen_mdy(input)
+                    .unwrap()
+                    .unwrap()
+                    .trunc_subsecs(0)
+                    .with_second(0)
+                    .unwrap(),
+                want.unwrap().trunc_subsecs(0).with_second(0).unwrap(),
+                "hyphen_mdy/{}",
+                input
+            )
+        }
+        assert!(parse.hyphen_mdy("not-date-time").is_none());
+    }
+
+    #[test]
+    fn hyphen_mdy_hms() {
+        let parse = Parse::new(&Utc, None);
+
+        let test_cases = vec![
+            ("4-8-2014 22:05", Utc.ymd(2014, 4, 8).and_hms(22, 5, 0)),
+            ("04-08-2014 22:05", Utc.ymd(2014, 4, 8).and_hms(22, 5, 0)),
+            ("4-8-14 22:05", Utc.ymd(2014, 4, 8).and_hms(22, 5, 0)),
+            ("04-2-2014 03:00:51", Utc.ymd(2014, 4, 2).and_hms(3, 0, 51)),
+            ("8-8-1965 12:00:00 AM", Utc.ymd(1965, 8, 8).and_hms(0, 0, 0)),
+            (
+                "8-8-1965 01:00:01 PM",
+                Utc.ymd(1965, 8, 8).and_hms(13, 0, 1),
+            ),
+            ("8-8-1965 01:00 PM", Utc.ymd(1965, 8, 8).and_hms(13, 0, 0)),
+            ("8-8-1965 1:00 PM", Utc.ymd(1965, 8, 8).and_hms(13, 0, 0)),
+            ("8-8-1965 12:00 AM", Utc.ymd(1965, 8, 8).and_hms(0, 0, 0)),
+            ("4-02-2014 03:00:51", Utc.ymd(2014, 4, 2).and_hms(3, 0, 51)),
+            (
+                "03-19-2012 10:11:59",
+                Utc.ymd(2012, 3, 19).and_hms(10, 11, 59),
+            ),
+            (
+                "03-19-2012 10:11:59.3186369",
+                Utc.ymd(2012, 3, 19).and_hms_nano(10, 11, 59, 318636900),
+            ),
+        ];
+
+        for &(input, want) in test_cases.iter() {
+            assert_eq!(
+                parse.hyphen_mdy_hms(input).unwrap().unwrap(),
+                want,
+                "hyphen_mdy_hms/{}",
+                input
+            )
+        }
+        assert!(parse.hyphen_mdy_hms("not-date-time").is_none());
+    }
+
 
     #[test]
     fn slash_ymd_hms() {


### PR DESCRIPTION
This PR adds support for date and timestamps which have their month, date and year part in `mm-dd-yyyy` format. I have borrowed the implementation from`slash_mdy_family` function and have added appropriate tests.
I had a use case where I needed to support this scenario, so I thought of creating this PR in case maintainer(s) think the package can benefit from it.