### PR TITLE
Resolved issue #53 - Wrong order of day and month in all dot-family date formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,13 +150,12 @@ More about this crate on [Docs.rs][1] and in [examples][2] folder
 // yyyy/mm/dd
 "2014/3/31",
 "2014/03/31",
-// mm.dd.yyyy
-"3.31.2014",
-"03.31.2014",
-"08.21.71",
-// yyyy.mm.dd
-"2014.03.30",
-"2014.03",
+// dd.mm.yyyy
+"31.3.2014",
+"31.03.2014",
+"21.08.71",
+// yyyy.dd.mm
+"2014.30.03",
 // yymmdd hh:mm:ss mysql log
 "171113 14:14:20",
 // chinese yyyy mm dd hh mm ss

--- a/dateparser/benches/parse.rs
+++ b/dateparser/benches/parse.rs
@@ -25,10 +25,11 @@ lazy_static! {
         "08/21/71",                      // slash_mdy
         "2012/03/19 10:11:59",           // slash_ymd_hms
         "2014/3/31",                     // slash_ymd
-        "2014.03.30",                    // dot_mdy_or_ymd
+        "2014.30.3",                     // dot_mdy_or_ymd
+        "28.09.2023",                    // dot_mdy_or_ymd
         "171113 14:14:20",               // mysql_log_timestamp
-        "2014年04月08日11时25分18秒",    // chinese_ymd_hms
-        "2014年04月08日",                // chinese_ymd
+        "2014年04月08日11时25分18秒",      // chinese_ymd_hms
+        "2014年04月08日",                 // chinese_ymd
     ];
 }
 


### PR DESCRIPTION
_Copied from GitHub issue description_

The current list of supported date time format includes two variants using the dot (.) as a delimiter, namely:
- mm.dd.yyyy
- yyyy.mm.dd

This seems very peculiar, since the usual order of these date formats is dd.mm.yyyy (Germany, Austria, Belgium, Belarus, Israel, Norway, Denmark, Sweden, Romania, Latvia, Estonia, Luxembourg, and many more) and yyyy.dd.mm (Kazakhstan). In fact, according to the English [Wikipedia list of date formats by country](https://en.wikipedia.org/wiki/List_of_date_formats_by_country), no country uses either one of the currently implemented formats.

Therefore, this is most cerntainly a simple mess-up of the day and month order.